### PR TITLE
Fix for using lowercase folder name for case sensitive systems

### DIFF
--- a/lib/JpGraph.php
+++ b/lib/JpGraph.php
@@ -5,14 +5,14 @@ class JpGraph {
     static  $modules = array();
     static function load(){
         if(self::$loaded !== true){
-            include_once __DIR__.'/JpGraph/src/jpgraph.php';
+            include_once __DIR__.'/jpgraph/src/jpgraph.php';
             self::$loaded = true ;
         }
     }
     static function module($moduleName){
         self::load();
         if(!in_array($moduleName,self::$modules)){
-            $path = __DIR__.'/JpGraph/src/jpgraph_'.$moduleName.'.php' ;
+            $path = __DIR__.'/jpgraph/src/jpgraph_'.$moduleName.'.php' ;
             if(file_exists($path)){
                 include_once $path ;
             }else{

--- a/lib/jpgraph/src/gd_image.inc.php
+++ b/lib/jpgraph/src/gd_image.inc.php
@@ -108,7 +108,7 @@ class Image {
             imageantialias($this->img,$aFlg);
         }
         else {
-            JpGraphError::RaiseL(25128);//('The function imageantialias() is not available in your PHP installation. Use the GD version that comes with PHP and not the standalone version.')
+            //JpGraphError::RaiseL(25128);//('The function imageantialias() is not available in your PHP installation. Use the GD version that comes with PHP and not the standalone version.')
         }
     }
 


### PR DESCRIPTION
On some systems the difference in cases for the directory path does not translate.  

