### PR TITLE
adding in short term fix for bug created by 2.3 libgd

### DIFF
--- a/lib/jpgraph/src/gd_image.inc.php
+++ b/lib/jpgraph/src/gd_image.inc.php
@@ -718,6 +718,9 @@ class Image {
 
     function imagettfbbox_fixed($size, $angle, $fontfile, $text) {
 
+        if($text === '') {
+            return [-1, 1, 1, 1, 1, -1, -1, -1];
+        }
 
         if( ! USE_LIBRARY_IMAGETTFBBOX ) {
 
@@ -930,9 +933,12 @@ class Image {
                     // This is only support for text at 0 degree !!
                     // Do nothing the text is drawn at baseline by default
                 }
-            } 
-            ImageTTFText ($this->img, $this->font_size, $dir, $x, $y,
+            }
+            if($txt !== '') {
+                ImageTTFText ($this->img, $this->font_size, $dir, $x, $y,
                           $this->current_color,$this->font_file,$txt);
+            }
+            
 
             // Calculate and return the co-ordinates for the bounding box
             $box = $this->imagettfbbox_fixed($this->font_size,$dir,$this->font_file,$txt);
@@ -1038,13 +1044,15 @@ class Image {
                 $xl -= $bbox[0]/2;
                 $yl = $y - $yadj;
                 //$xl = $xl- $xadj;
-                ImageTTFText($this->img, $this->font_size, $dir, $xl, $yl-($h-$fh)+$fh*$i,
+                if($tmp[$i] !== '') {
+                    ImageTTFText($this->img, $this->font_size, $dir, $xl, $yl-($h-$fh)+$fh*$i,
                              $this->current_color,$this->font_file,$tmp[$i]);
+                }            
 
                // echo "xl=$xl,".$tmp[$i]." <br>";
                 if( $debug  ) {
                     // Draw the bounding rectangle around each line
-                    $box=@ImageTTFBBox($this->font_size,$dir,$this->font_file,$tmp[$i]);
+                    $box = $this->getimagettfbbox_fixed($this->font_size,$dir,$this->font_file,$tmp[$i]);
                     $p = array();
                     for($j=0; $j < 4; ++$j) {
                         $p[] = $bbox[$j*2]+$xl;


### PR DESCRIPTION
Up to you if you'd like to accept this change or not, as it's more of an issue with libgd than it is with jpgraph, although, you could argue that trying to overlay empty text is kind of a bug...

Overall though, LibGD had a new release last month 2.3 that created a changed behavior for some PHP functions that rely on the underlying C library.  Because of that behavior, it now throws an exception for when you try to overlay a text image with TTF within JpGraph.

This PR adds in some code to correct this issue.

https://github.com/libgd/libgd/issues/615
https://bugs.php.net/bug.php?id=79415